### PR TITLE
Redesigned visualization

### DIFF
--- a/child_lab_framework/_procedure/demo_sequential.py
+++ b/child_lab_framework/_procedure/demo_sequential.py
@@ -8,6 +8,7 @@ from ..core.video import Format, Input, Reader, Writer
 from ..logging import Logger
 from ..task import depth, face, gaze, pose
 from ..task.camera import transformation
+from ..task.visualization import Configuration as VisualizationConfiguration
 from ..task.visualization import Visualizer
 
 BATCH_SIZE = 32
@@ -89,26 +90,38 @@ def main(
     # social_distance_estimator = social_distance.Estimator(executor)
     # social_distance_logger = social_distance.FileLogger('dev/output/distance.csv')
 
-    visualizer = Visualizer(
+    ceiling_visualizer = Visualizer(
+        executor,
+        properties=ceiling_reader.properties,
+        configuration=VisualizationConfiguration(),
+    )
+
+    window_left_visualizer = Visualizer(
         executor,
         properties=window_left_reader.properties,
-        confidence_threshold=0.5,
+        configuration=VisualizationConfiguration(),
+    )
+
+    window_right_visualizer = Visualizer(
+        executor,
+        properties=window_right_reader.properties,
+        configuration=VisualizationConfiguration(),
     )
 
     ceiling_writer = Writer(
-        str(output_directory / (ceiling.name + '.mp4')),
+        output_directory / (ceiling.name + '.mp4'),
         ceiling_reader.properties,
         output_format=Format.MP4,
     )
 
     window_left_writer = Writer(
-        str(output_directory / (window_left.name + '.mp4')),
+        output_directory / (window_left.name + '.mp4'),
         window_left_reader.properties,
         output_format=Format.MP4,
     )
 
     window_right_writer = Writer(
-        str(output_directory / (window_right.name + '.mp4')),
+        output_directory / (window_right.name + '.mp4'),
         window_right_reader.properties,
         output_format=Format.MP4,
     )
@@ -225,21 +238,20 @@ def main(
         Logger.info('Done!')
 
         Logger.info('Visualizing results...')
-        ceiling_annotated_frames = visualizer.annotate_batch(
+        ceiling_annotated_frames = ceiling_visualizer.annotate_batch(
             ceiling_frames,
             ceiling_poses,
-            None,
             ceiling_gazes,
         )
 
-        window_left_annotated_frames = visualizer.annotate_batch(
+        window_left_annotated_frames = window_left_visualizer.annotate_batch(
             window_left_frames,
             window_left_poses,
             window_left_faces,
             window_left_gazes,
         )
 
-        window_right_annotated_frames = visualizer.annotate_batch(
+        window_right_annotated_frames = window_right_visualizer.annotate_batch(
             window_right_frames,
             window_right_poses,
             window_right_faces,

--- a/child_lab_framework/_procedure/estimate_transformations.py
+++ b/child_lab_framework/_procedure/estimate_transformations.py
@@ -1,12 +1,15 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 import cv2
 import torch
 from tqdm import tqdm
 
 from ..core import transformation
+from ..core.calibration import Calibration
 from ..core.detection import marker
-from ..core.video import Input, Reader
+from ..core.video import Format, Input, Reader, Writer
+from ..task import visualization
 
 MARKER_PREFIX = 'marker'
 
@@ -21,38 +24,58 @@ class Config:
 # TODO: Implement procedures as classes with `Iterable` protocol
 # to make them both usable with tqdm and exportable as purely programistic library elements
 def run(
-    inputs: list[Input], config: Config, device: torch.device
+    video_sources: list[Path],
+    video_destinations: list[Path],
+    calibrations: list[Calibration],
+    config: Config,
+    device: torch.device,
 ) -> transformation.Buffer[str]:
-    if len(inputs) < 2:
+    if len(video_sources) < 2:
         raise ValueError('At least two inputs are required to estimate transformations')
 
     # TODO: Dump AruDice to config
-    buffer = transformation.Buffer({input.name for input in inputs})
+    buffer = transformation.Buffer({input.stem for input in video_sources})
 
-    readers = [Reader(input, batch_size=1) for input in inputs]
+    readers = [
+        Reader(Input(input.stem, input, calibration), batch_size=1)
+        for input, calibration in zip(video_sources, calibrations)
+    ]
 
-    marker_model = config.model
+    writers = [
+        Writer(destination, reader.properties, output_format=Format.MP4)
+        for destination, reader in zip(video_destinations, readers)
+    ]
 
-    marker_detector = marker.Detector(
-        model=marker_model,
+    detector = marker.Detector(
+        model=config.model,
         dictionary=config.dictionary,
         detector_parameters=config.detector_parameters,
     )
 
+    visualizer = visualization.Visualizer(
+        None,  # type: ignore
+        properties=readers[0].properties,
+        configuration=visualization.Configuration(),
+    )
+
     while not buffer.connected:
-        frames = [
-            (reader, frame) for reader in readers if (frame := reader.read()) is not None
+        views = [
+            (reader, writer, frame)
+            for reader, writer in zip(readers, writers)
+            if (frame := reader.read()) is not None
         ]
 
-        if len(frames) == 0:
+        if len(views) == 0:
             break
 
-        for reader, frame in tqdm(frames, 'Processing frames'):
-            marker_detector.calibration = reader.properties.calibration
-            markers = marker_detector.predict(frame)
+        for reader, writer, frame in tqdm(views, 'Processing frames'):
+            detector.calibration = reader.properties.calibration
+            markers = detector.predict(frame)
 
             if markers is None:
                 continue
+
+            writer.write(visualizer.annotate(frame, markers))
 
             id: int
             for id, marker_transformation in zip(markers.ids, markers.transformations):

--- a/child_lab_framework/core/detection/chessboard.py
+++ b/child_lab_framework/core/detection/chessboard.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from typing import Any
 
 import cv2 as opencv
 import numpy as np
 
+from ...task import visualization
 from ...typing.array import FloatArray2, FloatArray3
 from ...typing.video import Frame
 from .. import video
@@ -25,7 +25,7 @@ class Result:
         self,
         frame: Frame,
         frame_properties: video.Properties,
-        configuration: Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         if not configuration.chessboard_draw_corners:
             return frame

--- a/child_lab_framework/core/detection/chessboard.py
+++ b/child_lab_framework/core/detection/chessboard.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+from typing import Any
 
 import cv2 as opencv
 import numpy as np
 
 from ...typing.array import FloatArray2, FloatArray3
 from ...typing.video import Frame
+from .. import video
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,28 @@ class Properties:
 @dataclass(frozen=True)
 class Result:
     corners: FloatArray3
+    properties: Properties  # TODO: delete this field as soon as custom drawing procedure is implemented
+
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: video.Properties,
+        configuration: Any,  # TODO: Add hint
+    ) -> Frame:
+        if not configuration.chessboard_draw_corners:
+            return frame
+
+        properties = self.properties
+
+        pattern_shape = (
+            properties.inner_corners_per_row,
+            properties.inner_corners_per_column,
+        )
+
+        # TODO: implement custom drawing
+        opencv.drawChessboardCorners(frame, pattern_shape, self.corners, True)
+
+        return frame
 
 
 class Detector:
@@ -59,6 +83,7 @@ class Detector:
     # TODO: take grayscale frame as an argument to avoid conversion
     def predict(self, frame: Frame) -> Result | None:
         grayscale_frame = opencv.cvtColor(frame, opencv.COLOR_RGB2GRAY)
+        properties = self.properties
 
         found, corners_dirty = opencv.findChessboardCorners(  # type: ignore
             grayscale_frame,
@@ -77,4 +102,4 @@ class Detector:
             self.termination_criteria,
         )
 
-        return Result(np.stack(corners))
+        return Result(np.stack(corners), properties)

--- a/child_lab_framework/core/detection/marker.py
+++ b/child_lab_framework/core/detection/marker.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Self
+from typing import Any, Self
 
 import cv2 as opencv
 import cv2.aruco as opencv_aruco
@@ -10,6 +10,7 @@ from ...typing.array import FloatArray2, FloatArray3, IntArray1
 from ...typing.video import Frame
 from .. import serialization, transformation
 from ..calibration import Calibration
+from ..video import Properties
 
 
 # Can't stand that awful OpenCV's constants ported directly from C++; enum is better
@@ -120,6 +121,52 @@ class Result:
     corners: FloatArray3
     ids: IntArray1
     transformations: list[transformation.ProjectiveTransformation | None]
+
+    # TODO: Implement custom drawing procedure
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: Properties,
+        configuration: Any,  # TODO: Add hint
+    ) -> Frame:
+        draw_boxes = configuration.marker_draw_bounding_boxes
+        draw_ids = configuration.marker_draw_ids
+        draw_axes = configuration.marker_draw_axes
+        draw_angles = configuration.marker_draw_angles
+
+        if draw_boxes:
+            color = configuration.marker_bounding_box_color
+            opencv_aruco.drawDetectedMarkers(frame, list(self.corners), self.ids, color)
+
+        if draw_ids:
+            ...  # TODO: implement with custom procedure
+
+        calibration = frame_properties.calibration
+        intrinsics = calibration.intrinsics
+        distortion = calibration.distortion
+
+        if draw_axes:
+            length = configuration.marker_axis_length
+            thickness = configuration.marker_axis_thickness
+
+            for transformation in self.transformations:
+                if transformation is None:
+                    continue
+
+                opencv.drawFrameAxes(
+                    frame,
+                    intrinsics,
+                    distortion,
+                    transformation.rotation,
+                    transformation.translation,
+                    length,
+                    thickness,
+                )
+
+        if draw_angles:
+            ...  # TODO: draw rotation angles around axes
+
+        return frame
 
 
 class Detector:

--- a/child_lab_framework/core/detection/marker.py
+++ b/child_lab_framework/core/detection/marker.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, Self
+from typing import Self
 
 import cv2 as opencv
 import cv2.aruco as opencv_aruco
 import numpy as np
 
+from ...task import visualization
 from ...typing.array import FloatArray2, FloatArray3, IntArray1
 from ...typing.video import Frame
 from .. import serialization, transformation
@@ -127,7 +128,7 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         draw_boxes = configuration.marker_draw_bounding_boxes
         draw_ids = configuration.marker_draw_ids

--- a/child_lab_framework/core/video.py
+++ b/child_lab_framework/core/video.py
@@ -226,20 +226,31 @@ class Reader:
 
 
 class Writer:
-    destination: str
+    destination: Path
     properties: Properties
     output_format: Format
     encoder: cv2.VideoWriter
 
     def __init__(
-        self, destination: str, properties: Properties, *, output_format: Format
+        self,
+        destination: Path,
+        properties: Properties,
+        *,
+        output_format: Format,
     ) -> None:
         self.destination = destination
         self.properties = properties
         self.output_format = output_format
 
+        # TODO: Implement general resolution (Issue #61)
+        destination_with_resolved_format = (
+            str(destination).removesuffix(destination.suffix) + '.mp4'
+            if output_format == Format.MP4
+            else '.avi'
+        )
+
         self.encoder = cv2.VideoWriter(
-            destination,
+            destination_with_resolved_format,
             fourcc=cv2.VideoWriter.fourcc(*output_format.value),
             fps=int(properties.fps),
             frameSize=(int(properties.width), int(properties.height)),

--- a/child_lab_framework/task/face/face.py
+++ b/child_lab_framework/task/face/face.py
@@ -2,7 +2,6 @@ import asyncio
 from concurrent.futures.thread import ThreadPoolExecutor
 from dataclasses import dataclass
 from itertools import starmap
-from typing import Any
 
 import cv2
 import numpy as np
@@ -13,7 +12,7 @@ from ...core.video import Properties
 from ...typing.array import FloatArray1, FloatArray2, IntArray1
 from ...typing.stream import Fiber
 from ...typing.video import Frame
-from .. import pose
+from .. import pose, visualization
 from ..pose.keypoint import YoloKeypoint
 from . import mtcnn
 
@@ -29,10 +28,10 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         draw_boxes = configuration.face_draw_bounding_boxes
-        draw_confidences = configuration.face_draw_confidences
+        draw_confidences = configuration.face_draw_confidence
 
         if draw_boxes:
             color = configuration.face_bounding_box_color

--- a/child_lab_framework/task/face/face.py
+++ b/child_lab_framework/task/face/face.py
@@ -2,13 +2,15 @@ import asyncio
 from concurrent.futures.thread import ThreadPoolExecutor
 from dataclasses import dataclass
 from itertools import starmap
+from typing import Any
 
+import cv2
 import numpy as np
 
 from ...core.sequence import imputed_with_reference_inplace
 from ...core.stream import InvalidArgumentException
 from ...core.video import Properties
-from ...typing.array import FloatArray1, FloatArray2
+from ...typing.array import FloatArray1, FloatArray2, IntArray1
 from ...typing.stream import Fiber
 from ...typing.video import Frame
 from .. import pose
@@ -22,6 +24,29 @@ type Input = tuple[list[Frame] | None, list[pose.Result | None] | None]
 class Result:
     boxes: FloatArray2
     confidences: FloatArray1
+
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: Properties,
+        configuration: Any,  # TODO: Add hint
+    ) -> Frame:
+        draw_boxes = configuration.face_draw_bounding_boxes
+        draw_confidences = configuration.face_draw_confidences
+
+        if draw_boxes:
+            color = configuration.face_bounding_box_color
+            thickness = configuration.face_bounding_box_thickness
+
+            box: IntArray1
+            for box in self.boxes:
+                x1, y1, x2, y2 = box
+                cv2.rectangle(frame, (x1, y1), (x2, y2), color, thickness)
+
+        if draw_confidences:
+            ...  # TODO: annotate bounding boxes with confidence
+
+        return frame
 
 
 class Estimator:

--- a/child_lab_framework/task/gaze/ceiling_projection.py
+++ b/child_lab_framework/task/gaze/ceiling_projection.py
@@ -15,7 +15,7 @@ from ...logging import Logger
 from ...typing.array import BoolArray1, FloatArray1, FloatArray2
 from ...typing.stream import Fiber
 from ...typing.video import Frame
-from .. import face, pose
+from .. import face, pose, visualization
 from . import ceiling_baseline, gaze
 
 type Input = tuple[
@@ -39,7 +39,7 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: typing.Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         starts = self.centres
         ends = starts + 100.0 * self.directions

--- a/child_lab_framework/task/gaze/gaze.py
+++ b/child_lab_framework/task/gaze/gaze.py
@@ -17,7 +17,7 @@ from ...core.video import Frame, Properties
 from ...typing.array import FloatArray2, FloatArray3, IntArray1
 from ...typing.stream import Fiber
 from ...util import MODELS_DIR as MODELS_ROOT
-from .. import face
+from .. import face, visualization
 
 
 @dataclass
@@ -36,7 +36,7 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: typing.Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         if not configuration.gaze_draw_lines:
             return frame

--- a/child_lab_framework/task/gaze/gaze.py
+++ b/child_lab_framework/task/gaze/gaze.py
@@ -1,8 +1,10 @@
 import asyncio
+import typing
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from itertools import repeat, starmap
 
+import cv2
 import mini_face as mf
 import numpy as np
 
@@ -12,7 +14,7 @@ from ...core.sequence import (
 )
 from ...core.stream import InvalidArgumentException
 from ...core.video import Frame, Properties
-from ...typing.array import FloatArray3, IntArray1
+from ...typing.array import FloatArray2, FloatArray3, IntArray1
 from ...typing.stream import Fiber
 from ...util import MODELS_DIR as MODELS_ROOT
 from .. import face
@@ -29,6 +31,67 @@ class Result:
     eyes: FloatArray3
     directions: FloatArray3
     was_projected: bool = field(default=False)
+
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: Properties,
+        configuration: typing.Any,  # TODO: Add hint
+    ) -> Frame:
+        if not configuration.gaze_draw_lines:
+            return frame
+
+        color = configuration.gaze_line_color
+        thickness = configuration.gaze_line_thickness
+        line_length = configuration.gaze_line_length
+
+        calibration = frame_properties.calibration
+        cx, cy = calibration.optical_center
+        fx, fy = calibration.focal_length
+
+        # TODO: Project using `Projectable` (Issue #59)
+
+        # TODO: remove the rescale (Issue #60)
+        starts = self.eyes.copy() * 8.0 / 28.0
+        ends = starts + float(line_length) * self.directions
+
+        starts_z = starts[..., -1]
+        starts[..., 0] *= fx
+        starts[..., 1] *= fy
+        starts[..., 0] /= starts_z
+        starts[..., 1] /= starts_z
+        starts[..., 0] += cx
+        starts[..., 1] += cy
+
+        ends_z = ends[..., -1]
+        ends[..., 0] *= fx
+        ends[..., 1] *= fy
+        ends[..., 0] /= ends_z
+        ends[..., 1] /= ends_z
+        ends[..., 0] += cx
+        ends[..., 1] += cy
+
+        actor_starts: FloatArray2
+        actor_ends: FloatArray2
+
+        for actor_starts, actor_ends in zip(starts, ends):
+            cv2.line(
+                frame,
+                typing.cast(cv2.typing.Point, actor_starts[0, :2].astype(np.int32)),
+                typing.cast(cv2.typing.Point, actor_ends[0, :2].astype(np.int32)),
+                color,
+                thickness,
+            )
+
+            cv2.line(
+                frame,
+                typing.cast(cv2.typing.Point, actor_starts[1, :2].astype(np.int32)),
+                typing.cast(cv2.typing.Point, actor_ends[1, :2].astype(np.int32)),
+                color,
+                thickness,
+            )
+
+        return frame
 
 
 type Input = tuple[list[Frame], list[face.Result | None] | None]
@@ -73,10 +136,6 @@ class Estimator:
     def predict(self, frame: Frame, faces: face.Result) -> Result | None:
         extractor = self.extractor
 
-        cx = self.optical_center_x
-        cy = self.optical_center_y
-        center_shift = np.array((cx, cy, 0.0), dtype=np.float32).reshape(1, 1, -1)
-
         eyes: list[FloatArray3 | None] = []
         directions: list[FloatArray3 | None] = []  # in fact arrays are 1 x 2 x 3
 
@@ -94,7 +153,7 @@ class Estimator:
                 directions.append(None)
                 continue
 
-            eyes.append(detection.eyes + center_shift)
+            eyes.append(detection.eyes)  # type: ignore
             directions.append(detection.directions)  # type: ignore
 
         match (

--- a/child_lab_framework/task/pose/pose.py
+++ b/child_lab_framework/task/pose/pose.py
@@ -18,6 +18,7 @@ from ...core.video import Frame, Properties
 from ...typing.array import FloatArray1, FloatArray2, FloatArray3, IntArray1
 from ...typing.stream import Fiber
 from ...util import MODELS_DIR
+from .. import visualization
 from .duplication import deduplicated
 from .keypoint import YOLO_SKELETON, YoloKeypoint
 
@@ -102,12 +103,12 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: typing.Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         actor_keypoints: FloatArray2
 
         draw_skeletons = configuration.pose_draw_skeletons
-        draw_boxes = configuration.pose_draw_boxes
+        draw_boxes = configuration.pose_draw_bounding_boxes
 
         # TODO: draw keypoint confidence
         if draw_skeletons:

--- a/child_lab_framework/task/social_distance/social_distance.py
+++ b/child_lab_framework/task/social_distance/social_distance.py
@@ -2,7 +2,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TextIO
 
 import numpy as np
 from scipy.spatial.distance import pdist
@@ -11,7 +11,7 @@ from ...core.video import Properties
 from ...typing.array import FloatArray2
 from ...typing.stream import Fiber
 from ...typing.video import Frame
-from .. import pose
+from .. import pose, visualization
 
 
 @dataclass
@@ -24,7 +24,7 @@ class Result:
         self,
         frame: Frame,
         frame_properties: Properties,
-        configuration: Any,  # TODO: Add hint
+        configuration: visualization.Configuration,
     ) -> Frame:
         # TODO: Add actor centers to `Result` to be able to draw a line
         return frame

--- a/child_lab_framework/task/social_distance/social_distance.py
+++ b/child_lab_framework/task/social_distance/social_distance.py
@@ -2,13 +2,15 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 import numpy as np
 from scipy.spatial.distance import pdist
 
+from ...core.video import Properties
 from ...typing.array import FloatArray2
 from ...typing.stream import Fiber
+from ...typing.video import Frame
 from .. import pose
 
 
@@ -17,6 +19,15 @@ class Result:
     actors: list[pose.Actor]
     distances: FloatArray2
     # TODO: additional results (e.g. related to time series)
+
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: Properties,
+        configuration: Any,  # TODO: Add hint
+    ) -> Frame:
+        # TODO: Add actor centers to `Result` to be able to draw a line
+        return frame
 
 
 class Estimator:

--- a/child_lab_framework/task/visualization/__init__.py
+++ b/child_lab_framework/task/visualization/__init__.py
@@ -1,3 +1,4 @@
+from .configuration import Configuration
 from .visualization import Visualizer
 
-__all__ = ['Visualizer']
+__all__ = ['Configuration', 'Visualizer']

--- a/child_lab_framework/task/visualization/configuration.py
+++ b/child_lab_framework/task/visualization/configuration.py
@@ -17,6 +17,7 @@ class Configuration:
     gaze_line_color: Color = (255.0, 255.0, 0.0, 1.0)
     gaze_baseline_line_color: Color = (0.0, 255.0, 255.0, 1.0)
     gaze_line_thickness: int = 5
+    gaze_line_length: int = 250
 
     pose_draw_skeletons: bool = True
     pose_draw_skeletons_confidence: bool = True

--- a/child_lab_framework/task/visualization/configuration.py
+++ b/child_lab_framework/task/visualization/configuration.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+type Color = tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class Configuration:
+    face_draw_bounding_boxes: bool = True
+    face_bounding_box_color: Color = (255.0, 0.0, 0.0, 1.0)
+    face_bounding_box_thickness: int = 4
+    face_draw_confidence: bool = False
+    face_confidence_threshold: float = 0.5
+    face_confidence_color: Color = (255.0, 255.0, 255.0, 1.0)
+    face_confidence_size: int = 10
+
+    gaze_draw_lines: bool = True
+    gaze_line_color: Color = (255.0, 255.0, 0.0, 1.0)
+    gaze_baseline_line_color: Color = (0.0, 255.0, 255.0, 1.0)
+    gaze_line_thickness: int = 5
+
+    pose_draw_skeletons: bool = True
+    pose_draw_skeletons_confidence: bool = True
+    pose_bone_color: Color = (0.0, 0.0, 255.0, 1.0)
+    pose_bone_thickness: int = 2
+    pose_keypoint_color: Color = (0.0, 255.0, 0.0, 1.0)
+    pose_keypoint_radius: int = 5
+    pose_keypoint_confidence_threshold: float = 0.5
+    pose_keypoint_confidence_color: Color = (255.0, 255.0, 255.0, 1.0)
+    pose_keypoint_confidence_size: int = 10
+    pose_draw_bounding_boxes: bool = True
+    pose_draw_bounding_boxes_confidence: bool = True
+    pose_bounding_box_color: Color = (0.0, 255.0, 0.0, 1.0)
+    pose_bounding_box_thickness: int = 4
+    pose_bounding_box_confidence_threshold: float = 0.5
+    pose_bounding_box_confidence_color: Color = (255.0, 255.0, 255.0, 1.0)
+    pose_bounding_box_confidence_size: int = 10
+
+    social_proximity_draw_lines: bool = True
+    social_proximity_line_color: Color = (0.0, 0.0, 255.0, 1.0)
+    social_proximity_line_thickness: int = 3
+    social_proximity_draw_distance_value: bool = True
+    social_proximity_distance_value_color: Color = (255.0, 255.0, 0.0, 1.0)
+    social_proximity_distance_value_size: int = 10
+
+    chessboard_draw_corners: bool = True
+    chessboard_corner_color: Color = (255.0, 0.0, 0.0, 1.0)
+    chessboard_corner_radius: int = 3
+
+    marker_draw_bounding_boxes: bool = True
+    marker_bounding_box_color: Color = (255.0, 0.0, 0.0, 1.0)
+    marker_bounding_box_thickness: int = True
+    marker_draw_ids: bool = True
+    marker_id_color: Color = (0.0, 255.0, 0.0, 1.0)
+    marker_id_size: int = 10
+    marker_draw_axes: bool = True
+    marker_axis_length: int = 10
+    marker_axis_thickness: int = 2
+    marker_draw_angles: bool = True
+    marker_angle_color: Color = (255.0, 255.0, 255.0, 1.0)
+    marker_angle_size: int = 10

--- a/child_lab_framework/task/visualization/visualization.py
+++ b/child_lab_framework/task/visualization/visualization.py
@@ -1,23 +1,12 @@
 import typing
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
+from functools import reduce
 from itertools import repeat, starmap
 
-import cv2
-import numpy as np
-
 from ...core.video import Frame, Properties
-from ...typing.array import FloatArray1, FloatArray2, IntArray1
 from ...typing.stream import Fiber
-from .. import face, gaze, pose
-from ..gaze import ceiling_projection
-from ..pose.keypoint import YOLO_SKELETON, YoloKeypoint
 from .configuration import Configuration
-
-type Input = tuple[
-    list[Frame] | None,
-    list[pose.Result | None] | None,
-    list[ceiling_projection.Result | None] | None,
-]
 
 
 class Visualizable[T: Configuration](typing.Protocol):
@@ -29,206 +18,76 @@ class Visualizable[T: Configuration](typing.Protocol):
     ) -> Frame: ...
 
 
-class Visualizer:
-    BONE_COLOR = (0.0, 0.0, 255.0, 1.0)
-    BONE_THICKNESS = 2
-
-    POSE_BOUNDING_BOX_COLOR = (0.0, 255.0, 0.0, 1.0)
-    POSE_BOUNDING_BOX_THICKNESS = 4
-
-    FACE_BOUNDING_BOX_COLOR = (255.0, 0.0, 0.0, 1.0)
-    FACE_BOUNDING_BOX_THICKNESS = 3
-
-    GAZE_COLOR = (0.0, 255.0, 255.0, 1.0)
-    CORRECTED_GAZE_COLOR = (255.0, 255.0, 0.0, 1.0)
-    GAZE_THICKNESS = 5
-
-    JOINT_RADIUS = 5
-    JOINT_COLOR = (0.0, 255.0, 0.0, 1.0)
+class Visualizer[T: Configuration]:
+    executor: ThreadPoolExecutor
 
     properties: Properties
-    confidence_threshold: float
-
-    executor: ThreadPoolExecutor
+    configuration: T
 
     def __init__(
         self,
         executor: ThreadPoolExecutor,
         *,
         properties: Properties,
-        confidence_threshold: float,
+        configuration: T,
     ) -> None:
+        self.executor = executor
         self.properties = properties
-        self.confidence_threshold = confidence_threshold
+        self.configuration = configuration
 
-    def __draw_skeleton_and_joints(self, frame: Frame, result: pose.Result) -> Frame:
-        actor_keypoints: FloatArray2
-
-        for actor_keypoints in result.keypoints:
-            for i, j in YOLO_SKELETON:
-                if actor_keypoints[i, -1] < self.confidence_threshold:
-                    continue
-
-                if actor_keypoints[j, -1] < self.confidence_threshold:
-                    continue
-
-                start = typing.cast(cv2.typing.Point, actor_keypoints[i, :-1].astype(int))
-                end = typing.cast(cv2.typing.Point, actor_keypoints[j, :-1].astype(int))
-
-                cv2.line(frame, start, end, self.BONE_COLOR, self.BONE_THICKNESS)
-
-            for keypoint in actor_keypoints:
-                if keypoint[-1] < self.confidence_threshold:
-                    continue
-
-                keypoint = typing.cast(cv2.typing.Point, keypoint.astype(int))
-
-                cv2.circle(frame, keypoint[:-1], self.JOINT_RADIUS, self.JOINT_COLOR, -1)
-
-        return frame
-
-    def __draw_pose_boxes(self, frame: Frame, result: pose.Result) -> Frame:
-        color = self.POSE_BOUNDING_BOX_COLOR
-        thickness = self.POSE_BOUNDING_BOX_THICKNESS
-
-        box: IntArray1
-        for box in result.boxes.astype(int):
-            x1, y1, x2, y2, *_ = box
-            cv2.rectangle(frame, (x1, y1), (x2, y2), color, thickness)  # type: ignore
-
-        return frame
-
-    def __draw_projected_gaze(
-        self, frame: Frame, result: ceiling_projection.Result
-    ) -> Frame:
-        starts = result.centres
-        ends = starts + 100.0 * result.directions
-
-        start: FloatArray1
-        end: FloatArray1
-
-        thickness = self.GAZE_THICKNESS
-
-        for start, end, was_corrected in zip(starts, ends, result.was_corrected):
-            color = self.CORRECTED_GAZE_COLOR if was_corrected else self.GAZE_COLOR
-
-            cv2.line(
-                frame,
-                typing.cast(cv2.typing.Point, start.astype(np.int32)),
-                typing.cast(cv2.typing.Point, end.astype(np.int32)),
-                color,
-                thickness,
-            )
-
-        return frame
-
-    def __draw_gaze(self, frame: Frame, poses: pose.Result, gazes: gaze.Result) -> Frame:
-        calibration = self.properties.calibration
-        fx, fy = calibration.focal_length
-
-        directions = np.mean(gazes.directions, axis=1)
-        directions[:, 0] *= fx
-        directions[:, 1] *= fy
-        directions[:, 0] /= directions[:, -1]
-        directions[:, 1] /= directions[:, -1]
-        directions *= 100.0
-
-        starts = poses.keypoints[:, YoloKeypoint.NOSE, :2]
-        ends = starts - directions[:, -1]
-
-        start: FloatArray1
-        end: FloatArray1
-
-        color = self.CORRECTED_GAZE_COLOR
-        thickness = self.GAZE_THICKNESS
-
-        for start, end in zip(starts, ends):
-            cv2.line(
-                frame,
-                typing.cast(cv2.typing.Point, start.astype(np.int32)),
-                typing.cast(cv2.typing.Point, end.astype(np.int32)),
-                color,
-                thickness,
-            )
-
-        return frame
-
-    def __draw_face_box(self, frame: Frame, result: face.Result) -> Frame:
-        color = self.FACE_BOUNDING_BOX_COLOR
-        thickness = self.FACE_BOUNDING_BOX_THICKNESS
-
-        box: IntArray1
-        for box in result.boxes:
-            x1, y1, x2, y2 = box
-            cv2.rectangle(frame, (x1, y1), (x2, y2), color, thickness)
-
-        return frame
-
-    def __annotate_safe(
-        self,
-        frame: Frame,
-        poses: pose.Result | None,
-        faces: face.Result | None,
-        gazes: gaze.Result | ceiling_projection.Result | None,
-    ) -> Frame:
-        out = frame.copy()
-        out.flags.writeable = True
-
-        if poses is not None:
-            out = self.__draw_skeleton_and_joints(out, poses)
-            out = self.__draw_pose_boxes(out, poses)
-
-        if faces is not None:
-            out = self.__draw_face_box(out, faces)
-
-        if poses is not None and gazes is not None:
-            if isinstance(gazes, gaze.Result):
-                out = self.__draw_gaze(out, poses, gazes)
-
-            elif isinstance(gazes, ceiling_projection.Result):
-                out = self.__draw_projected_gaze(out, gazes)
-
-        return out
+    def annotate(self, frame: Frame, *results: Visualizable[T]) -> Frame:
+        return self.__annotate(frame, *results)
 
     def annotate_batch(
         self,
         frames: list[Frame],
-        poses: list[pose.Result] | None,
-        faces: list[face.Result] | None,
-        gazes: list[gaze.Result] | list[ceiling_projection.Result] | None,
+        *results: Sequence[Visualizable[T] | None] | None,
     ) -> list[Frame]:
         return list(
             starmap(
-                self.__annotate_safe,
-                zip(
-                    frames,
-                    poses or repeat(None),
-                    faces or repeat(None),
-                    gazes or repeat(None),
-                ),
+                self.__annotate,
+                zip(frames, *filter(None, results)),
             )
         )
 
-    async def stream(self) -> Fiber[Input, list[Frame] | None]:
+    def __annotate(self, frame: Frame, *results: Visualizable[T] | None) -> Frame:
+        frame = frame.copy()
+        frame.flags.writeable = True
+        properties = self.properties
+        configuration = self.configuration
+
+        return reduce(
+            lambda frame, result: result.visualize(frame, properties, configuration),
+            filter(None, results),
+            frame,
+        )
+
+    async def stream(
+        self,
+    ) -> Fiber[
+        tuple[list[Frame] | None, *tuple[list[Visualizable[T] | None] | None, ...]],
+        list[Frame] | None,
+    ]:
         annotated_frames: list[Frame] | None = None
 
         while True:
             match (yield annotated_frames):
-                case list(frames), None, None, None:
-                    annotated_frames = frames
-
-                case list(frames), poses, gazes:
+                case list(frames), *results if any(results):
                     annotated_frames = list(
                         starmap(
-                            self.__annotate_safe,
+                            self.__annotate,
                             zip(
                                 frames,
-                                poses or repeat(None),
-                                # faces or repeat(None),
-                                gazes or repeat(None),
+                                *map(
+                                    lambda result: result or repeat(None),
+                                    results,
+                                ),
                             ),
                         )
                     )
+
+                case list(frames), *_:
+                    annotated_frames = frames
 
                 case _:
                     annotated_frames = None

--- a/child_lab_framework/task/visualization/visualization.py
+++ b/child_lab_framework/task/visualization/visualization.py
@@ -11,12 +11,22 @@ from ...typing.stream import Fiber
 from .. import face, gaze, pose
 from ..gaze import ceiling_projection
 from ..pose.keypoint import YOLO_SKELETON, YoloKeypoint
+from .configuration import Configuration
 
 type Input = tuple[
     list[Frame] | None,
     list[pose.Result | None] | None,
     list[ceiling_projection.Result | None] | None,
 ]
+
+
+class Visualizable[T: Configuration](typing.Protocol):
+    def visualize(
+        self,
+        frame: Frame,
+        frame_properties: Properties,
+        configuration: T,
+    ) -> Frame: ...
 
 
 class Visualizer:


### PR DESCRIPTION
Closes #46

## Changes
* New `Visualizable` protocol indicates that object can be drawn on a frame
* All `Result`s implement `Visualizable`
* `Visualizer` is no longer implementing the drawing logic for particular `Results`. Instead, it calls methods from `Visualizable` on them and accumulates obtained drawings for each frame.
* `calibrate` command now expects a `workspace` argument and positive number of `videos`, identically to `process`
* `calibrate` and `process` save annotated videos:
      * `calibrate` draws chessboard corners on analyzed frames
      * `process` draws marker bounding boxes, ids and local coordinate axes
* `Writer` now takes `Path` instead of `str` as a destination