### PR TITLE
Allowed retrieval of transformation buffer from file in `process` command

### DIFF
--- a/child_lab_framework/core/transformation/buffer.py
+++ b/child_lab_framework/core/transformation/buffer.py
@@ -100,7 +100,7 @@ class Buffer[T: Hashable]:
         )
 
         if self.__compress_paths:
-            self.connections.add_edge(*from_to, transformation=transformation)
+            self.__connections.add_edge(*from_to, transformation=transformation)
 
         self.__frames_of_reference.add(from_to[0])
         self.__frames_of_reference.add(from_to[1])

--- a/child_lab_framework/core/transformation/transformation.py
+++ b/child_lab_framework/core/transformation/transformation.py
@@ -206,10 +206,11 @@ class ProjectiveTransformation(Transformation):
 
 def _join(rotation: FloatArray2, translation: FloatArray1) -> FloatArray2:
     m = np.zeros((4, 4), dtype=np.float32)
-    m[:3, :3] = translation
-    m[2, :3] = translation
+    m[:3, :3] = rotation
+    m[3, :3] = np.squeeze(translation)
+    m[3, 3] = 1.0
     return m
 
 
 def _split(transformation: FloatArray2) -> tuple[FloatArray2, FloatArray1]:
-    return transformation[:3, :3], transformation[2, :3]
+    return transformation[:3, :3], transformation[3, :3]


### PR DESCRIPTION
## Changes
* The default way to transform between cameras now is to provide a precalculated `transformation.Buffer`
* `process` command searches for `<workspace/>transformation/buffer.json` to obtain a serialized buffer
* New flag - `--dynamic-transformations` allows heuristic transformation estimation. Passing it is the only way to perform analysis without providing a precomputed buffer
* Final state of the `Buffer` after processing is serialized and saved in `<workspace>/output`