### PR TITLE
Made executors optional in all Estimators

### DIFF
--- a/child_lab_framework/_procedure/calibrate.py
+++ b/child_lab_framework/_procedure/calibrate.py
@@ -33,7 +33,6 @@ def run(
     )
 
     visualizer = Visualizer(
-        None,  # type: ignore
         properties=video_properties,
         configuration=Configuration(),
     )

--- a/child_lab_framework/_procedure/estimate_transformations.py
+++ b/child_lab_framework/_procedure/estimate_transformations.py
@@ -53,7 +53,6 @@ def run(
     )
 
     visualizer = visualization.Visualizer(
-        None,  # type: ignore
         properties=readers[0].properties,
         configuration=visualization.Configuration(),
     )

--- a/child_lab_framework/task/camera/transformation/heuristic/heuristic.py
+++ b/child_lab_framework/task/camera/transformation/heuristic/heuristic.py
@@ -19,7 +19,7 @@ type Input = tuple[
 
 
 class Estimator:
-    executor: ThreadPoolExecutor
+    executor: ThreadPoolExecutor | None
     transformation_buffer: Buffer[str]
 
     from_view: Properties
@@ -29,12 +29,12 @@ class Estimator:
 
     def __init__(
         self,
-        executor: ThreadPoolExecutor,
         transformation_buffer: Buffer[str],
         from_view: Properties,
         to_view: Properties,
         *,
         keypoint_threshold: float = 0.25,
+        executor: ThreadPoolExecutor | None = None,
     ) -> None:
         self.executor = executor
 
@@ -149,8 +149,13 @@ class Estimator:
     async def stream(
         self,
     ) -> Fiber[Input | None, list[Transformation | None] | None]:
-        loop = asyncio.get_running_loop()
         executor = self.executor
+        if executor is None:
+            raise RuntimeError(
+                'Processing in the stream mode requires the Estimator to have an executor. Please pass an "executor" argument to the estimator constructor'
+            )
+
+        loop = asyncio.get_running_loop()
 
         results: list[Transformation | None] | None = None
 

--- a/child_lab_framework/task/face/face.py
+++ b/child_lab_framework/task/face/face.py
@@ -49,7 +49,7 @@ class Result:
 
 
 class Estimator:
-    executor: ThreadPoolExecutor
+    executor: ThreadPoolExecutor | None
     device: torch.device
 
     input: Properties
@@ -58,12 +58,12 @@ class Estimator:
 
     def __init__(
         self,
-        executor: ThreadPoolExecutor,
         device: torch.device,
         *,
         input: Properties,
         confidence_threshold: float,
         suppression_threshold: float,
+        executor: ThreadPoolExecutor | None = None,
     ) -> None:
         self.executor = executor
         self.device = device
@@ -171,6 +171,11 @@ class Estimator:
 
     async def stream(self) -> Fiber[Input | None, list[Result | None] | None]:
         executor = self.executor
+        if executor is None:
+            raise RuntimeError(
+                'Processing in the stream mode requires the Estimator to have an executor. Please pass an "executor" argument to the estimator constructor'
+            )
+
         loop = asyncio.get_running_loop()
 
         results: list[Result | None] | None = None

--- a/child_lab_framework/task/gaze/ceiling_projection.py
+++ b/child_lab_framework/task/gaze/ceiling_projection.py
@@ -66,7 +66,7 @@ class Result:
 
 
 class Estimator:
-    executor: ThreadPoolExecutor
+    executor: ThreadPoolExecutor | None
 
     transformation_buffer: transformation.Buffer[str]
 
@@ -76,11 +76,12 @@ class Estimator:
 
     def __init__(
         self,
-        executor: ThreadPoolExecutor,
         transformation_buffer: transformation.Buffer[str],
         ceiling_properties: Properties,
         window_left_properties: Properties,
         window_right_properties: Properties,
+        *,
+        executor: ThreadPoolExecutor | None = None,
     ) -> None:
         self.executor = executor
         self.transformation_buffer = transformation_buffer
@@ -204,6 +205,11 @@ class Estimator:
     # NOTE: heuristic idea: actors seen from right and left are in reversed lexicographic order
     async def stream(self) -> Fiber[Input | None, list[Result | None] | None]:
         executor = self.executor
+        if executor is None:
+            raise RuntimeError(
+                'Processing in the stream mode requires the Estimator to have an executor. Please pass an "executor" argument to the estimator constructor'
+            )
+
         loop = asyncio.get_running_loop()
 
         results: list[Result | None] | None = None

--- a/child_lab_framework/task/gaze/gaze.py
+++ b/child_lab_framework/task/gaze/gaze.py
@@ -298,16 +298,16 @@ class Estimator:
 
     extractor: mf.gaze.Extractor
 
-    executor: ThreadPoolExecutor
+    executor: ThreadPoolExecutor | None
 
     def __init__(
         self,
-        executor: ThreadPoolExecutor,
         *,
         input: Properties,
         wild: bool = False,
         multiple_views: bool = False,
         limit_angles: bool = False,
+        executor: ThreadPoolExecutor | None = None,
     ) -> None:
         self.executor = executor
 
@@ -375,6 +375,11 @@ class Estimator:
 
     async def stream(self) -> Fiber[Input | None, list[Result3d | None] | None]:
         executor = self.executor
+        if executor is None:
+            raise RuntimeError(
+                'Processing in the stream mode requires the Estimator to have an executor. Please pass an "executor" argument to the estimator constructor'
+            )
+
         loop = asyncio.get_running_loop()
 
         results: list[Result3d | None] | None = None

--- a/child_lab_framework/task/visualization/visualization.py
+++ b/child_lab_framework/task/visualization/visualization.py
@@ -1,6 +1,5 @@
 import typing
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from functools import reduce
 from itertools import repeat, starmap
 
@@ -19,19 +18,15 @@ class Visualizable[T: Configuration](typing.Protocol):
 
 
 class Visualizer[T: Configuration]:
-    executor: ThreadPoolExecutor
-
     properties: Properties
     configuration: T
 
     def __init__(
         self,
-        executor: ThreadPoolExecutor,
         *,
         properties: Properties,
         configuration: T,
     ) -> None:
-        self.executor = executor
         self.properties = properties
         self.configuration = configuration
 


### PR DESCRIPTION
Closes [#72](https://github.com/child-lab-uj/child-lab-framework/issues/72)

## Changes
* `Estimators` no longer require `ThreadPoolExecutor` upon construction
* Executors are used only in `.stream()` methods
* `stream` checks for the executor at runtime and throws a `RuntimeError` in case of lacking it