### PR TITLE
Removed implicit, non-local behaviour from the depth estimator

### DIFF
--- a/child_lab_framework/_procedure/demo_sequential.py
+++ b/child_lab_framework/_procedure/demo_sequential.py
@@ -58,7 +58,7 @@ def main(
     )
     window_right_properties = window_right_reader.properties
 
-    depth_estimator = depth.Estimator(device, input=ceiling_properties)
+    depth_estimator = depth.Estimator(device)
 
     transformation_buffer = transformation_buffer or transformation.Buffer()
 


### PR DESCRIPTION
## Changes
* Invalid behaviour related to resizing the output has been fixed
* Depth estimator no longer expects the input `Properties` upon construction
* `Fiber` associated with the estimator expects two arguments: video frame and input properties. This will allow using a single depth estimator for multiple inputs in the stream context