### PR TITLE
Added the type checking step to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check lints
         run: uv run ruff check
 
+      - name: Check types
+        run: uv run mypy . --config-file pyproject.toml
+
   typos:
     name: Check typos
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes: #31 

## Changes
* The CI workflow now contains a step of type checking using `MyPy`, according to the configuration from `pyproject.toml`