### PR TITLE
Fix coordinate clipping in `draw_point_with_description`

### DIFF
--- a/packages/video-io/src/video_io/annotation.py
+++ b/packages/video-io/src/video_io/annotation.py
@@ -247,4 +247,4 @@ class Comparable(Protocol):
 
 
 def __clip[T: Comparable](value: T, min_value: T, max_value: T) -> T:
-    return min(min_value, max(value, max_value))
+    return max(min_value, min(value, max_value))


### PR DESCRIPTION
**Stack**:
- #169
- #168
- #167
- #166
- #165 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*